### PR TITLE
Added .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ npm-debug.log
 yarn-error.log
 .idea
 local/
+.DS_Store


### PR DESCRIPTION
.DS_Store is a useless file that macOS automatically generates in all folders to save the positions of folders in the directory, it is useless on windows and is an annoying file.