### PR TITLE
Added htaccess rules for word and dictionary pages

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -14,6 +14,16 @@
     # RewriteCond %{REQUEST_URI} (.+)/$
     # RewriteRule ^ %1 [L,R=301]
 
+    # Old page redirects
+    RewriteCond %{SCRIPT_FILENAME} word.php
+    RewriteCond %{QUERY_STRING} ^q=(.*)
+    RewriteRule (.*) /word/%1/? [R=301,L]
+
+
+    RewriteCond %{SCRIPT_FILENAME} dictionary
+    RewriteCond %{QUERY_STRING} ^filter=(.*)
+    RewriteRule (.*) /dictionary/%1/? [R=301,L]
+
     # Send Requests To Front Controller...
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f


### PR DESCRIPTION
This commit fixes a problem presented by the Laravel conversion. Old search engine indexing and previous user bookmarks would present a 404 error. The word and dictionary pages will now properly redirect to the new routes.