### PR TITLE
[FIX] Issue #25 trig->trig not trig->English

### DIFF
--- a/resources/views/word/lookup.blade.php
+++ b/resources/views/word/lookup.blade.php
@@ -35,7 +35,7 @@
                                 @endforeach
                             </tr>
                             <tr class="en_text">
-                                <td colspan="10">{{ $translation->trigedasleng }}</td>
+                                <td colspan="10">{{ $translation->translation }}</td>
                             </tr>
                             </tbody>
                         </table>


### PR DESCRIPTION
*FIX
Anchor en_text should now display English correctly again. This should resolve issue #25 