### PR TITLE
Add individual translation pages

### DIFF
--- a/app/Http/Controllers/WebController.php
+++ b/app/Http/Controllers/WebController.php
@@ -67,6 +67,7 @@ class WebController extends Controller
             'status'=> 'Updated word successfully!',
         ]);
     }
+
     public function translationLookup(Request $request, $id){
         $translationInfo = DB::selectOne("SELECT * FROM `dict_translations` WHERE `id`=?", ["{$id}"]);
         if(!isset($translationInfo)){
@@ -74,8 +75,10 @@ class WebController extends Controller
                 'translation' => $id,
             ]), 404);
         }
+        $citation = DB::selectOne('SELECT * FROM `dict_sources` WHERE `id`=?', [$translationInfo->source]);
         return view('translation.lookup', [
-            'translation' => $translationInfo
+            'translation' => $translationInfo,
+            'citation' => $citation,
         ]);
     }
 

--- a/app/Http/Controllers/WebController.php
+++ b/app/Http/Controllers/WebController.php
@@ -67,6 +67,53 @@ class WebController extends Controller
             'status'=> 'Updated word successfully!',
         ]);
     }
+    public function translationLookup(Request $request, $id){
+        $translationInfo = DB::selectOne("SELECT * FROM `dict_translations` WHERE `id`=?", ["{$id}"]);
+        if(!isset($translationInfo)){
+            return response(view('translation.lookup', [
+                'translation' => $id,
+            ]), 404);
+        }
+        return view('translation.lookup', [
+            'translation' => $translationInfo
+        ]);
+    }
+
+    public function translationEdit(Request $request, $id){
+        if((int) session('admin') !== 1){
+            return redirect(route('translation.lookup', $id));
+        }
+        $translationInfo = DB::selectOne('SELECT * FROM `dict_translations` WHERE `id`= ?', [$id]);
+        $source = DB::selectOne('SELECT * FROM `dict_sources` WHERE `id`=?', [$translationInfo->source]);
+        return view('translation.edit', [
+            'translation' => $translationInfo,
+            'source' => $source,
+        ]);
+    }
+
+    public function translationEditSubmit(Request $request, $id){
+        if((int) session('admin') !== 1){
+            return redirect(route('translation.lookup', $id));
+        }
+
+        $update = DB::table('dict_translations')->where('id', '=', $request->id)->update([
+            'trigedasleng' => $request->trig,
+            'translation' => $request->translation,
+            'etymology' => $request->etymology,
+            'leipzig' => $request->leipzig,
+            'episode' => $request->episode,
+            'audio' => $request->audio,
+            'speaker' => $request->speaker,
+            'source' => $request->source,
+        ]);
+        $translationInfo = DB::selectOne('SELECT * FROM `dict_translations` WHERE `id`= ?', [$request->id]);
+        $source = DB::selectOne('SELECT * FROM `dict_sources` WHERE `id`=?', [$translationInfo->source]);
+        return view('translation.edit', [
+            'translation' => $translationInfo,
+            'source' => $source,
+            'status'=> 'Updated translation successfully!',
+        ]);
+    }
 
     public function dictionaryLookup(Request $request, $dictionary = null){
         if($request->has('filter')){

--- a/app/Http/Controllers/WebController.php
+++ b/app/Http/Controllers/WebController.php
@@ -69,7 +69,7 @@ class WebController extends Controller
     }
 
     public function translationLookup(Request $request, $id){
-        $translationInfo = DB::selectOne("SELECT * FROM `dict_translations` WHERE `id`=?", ["{$id}"]);
+        $translationInfo = DB::selectOne("SELECT * FROM `dict_translations` WHERE `id`=?", [$id]);
         if(!isset($translationInfo)){
             return response(view('translation.lookup', [
                 'translation' => $id,

--- a/resources/views/search.blade.php
+++ b/resources/views/search.blade.php
@@ -28,7 +28,7 @@
                 @foreach($translations as $translation)
                     <div class="entry unflagged">
                         <table class="gloss">
-                            <tbody><tr class="tgs_text"><td colspan="10"><a href="#">{{ $translation->trigedasleng }}</a></td></tr>
+                            <tbody><tr class="tgs_text"><td colspan="10"><a href="/translation/{{$translation->id}}">{{ $translation->trigedasleng }}</a></td></tr>
                             <tr class="tgs" style="display: table-row;">
                                 @foreach(explode(' ', $translation->trigedasleng) as $word)
                                     <td>{{ $word }}</td>

--- a/resources/views/translation/edit.blade.php
+++ b/resources/views/translation/edit.blade.php
@@ -1,0 +1,36 @@
+@extends('layouts.default.app')
+
+@section('title', "{$translation->translation} - Edit")
+
+@section('content')
+    <div id="inner">
+        <div id="admin-form">
+            <h1>Editing id: {{ $translation->id }}</h1>
+            <form name="form" method="post" action="{{ route('translation.edit.submit', [$translation->id]) }}">
+                @csrf
+                <input type="hidden" name="action" value="editword" />
+                <input type="hidden" name="id" value="{{ $translation->id }}" />
+                <strong>Sentence / Phrase</strong><br>
+                <input type="text" name="trig" placeholder="Enter sentence (in trig)" value="{{ $translation->trigedasleng }}" required /><br>
+                <strong>Translation</strong><br>
+                <input type="text" name="translation" placeholder="Enter Translation" value="{{ $translation->translation }}" required /><br>
+                <strong>Etymology</strong><br>
+                <input type="text" name="etymology" placeholder="Enter Etymology" value="{{ $translation->etymology }}"/><br>
+                <strong>Leipzig</strong><br>
+                <input type="text" name="leipzig" placeholder="Enter Leipzig" value="{{ $translation->leipzig }}"/><br>
+                <strong>Episode</strong><br>
+                <input type="text" name="episode" placeholder="Enter Episode" value="{{ $translation->episode }}"/><br>
+                <strong>Audio</strong><br>
+                <input type="text" name="audio" placeholder="Enter Path to audio" value="{{ $translation->audio }}"/><br>
+                <strong>Speaker</strong><br>
+                <input type="text" name="speaker" placeholder="Enter Speaker" value="{{ $translation->speaker }}"/><br>
+                <strong>Source? (use #id from <a href="{{ route('sources') }}">Sources</a>)</strong><br>
+                <input type="text" name="source" placeholder="Enter #ID" value="@isset($source){{ $source->id }}@endisset" /><br>
+                <p><input name="submit" type="submit" value="Submit" /></p>
+            </form>
+            @isset($status)
+                <p style="color:#FF0000;">{{ $status }}</p>
+            @endisset
+        </div>
+    </div>
+@endsection

--- a/resources/views/translation/lookup.blade.php
+++ b/resources/views/translation/lookup.blade.php
@@ -35,13 +35,13 @@
                     </br>
             </div>
             <h3 class="citations">Sources:</h3>
-            {{-- @if($citation !== null)
+            @if($citation !== null)
                 <ul class="citations">
                     <li><a href="{{ $citation->url }}">{{ $citation->title }}</a></li>
                 </ul>
             @else
                 <p>None</p>
-            @endif --}}
+            @endif
             <div id="output"></div>
         </div>
     @else

--- a/resources/views/translation/lookup.blade.php
+++ b/resources/views/translation/lookup.blade.php
@@ -1,0 +1,52 @@
+@extends('layouts.default.app')
+
+@section('title', is_object($translation) ? $translation->trigedasleng : $translation)
+
+@section('content')
+    @if(is_object($translation))
+        <div id="inner">
+            <h1>{{ $translation->trigedasleng}}
+                @if(session('admin') && (int) session('admin') === 1)
+                    <a style="border-bottom: none;" href="{{ route('translation.edit', [$translation->id]) }}"><i class="far fa-edit"></i></a>
+                @endif
+            </h1>
+            <div class="translation">
+                    <div class="entry unflagged">
+                        <table class="gloss">
+                            <tbody><tr class="tgs_text"><td colspan="10">{{ $translation->trigedasleng }}</td></tr>
+                            <tr class="ety" style="display: table-row;">
+                                <td>{{ $translation->etymology }}</td>
+                            </tr>
+                            <tr class="leipzig" style="display: table-row;">
+                                <td>{{ $translation->leipzig }}</td>
+                            </tr>
+                            <tr class="en_text">
+                                <td colspan="10">{{ $translation->translation }}</td>
+                            </tr>
+                            </tbody>
+                        </table>
+
+                        @if($translation->audio !== '')
+                            <audio controls="">
+                                <source src="/{{ $translation->audio }}" type="audio/mpeg">
+                            </audio>
+                        @endif
+                    </div>
+                    </br>
+            </div>
+            <h3 class="citations">Sources:</h3>
+            {{-- @if($citation !== null)
+                <ul class="citations">
+                    <li><a href="{{ $citation->url }}">{{ $citation->title }}</a></li>
+                </ul>
+            @else
+                <p>None</p>
+            @endif --}}
+            <div id="output"></div>
+        </div>
+    @else
+        <div id="inner">
+            <h1>Translation id: {{ $translation->id }} does not exist.</h1>
+        </div>
+    @endif
+@endsection

--- a/resources/views/translations.blade.php
+++ b/resources/views/translations.blade.php
@@ -33,7 +33,7 @@
                     @foreach($translationList[$number] as $translation)
                         <div class="entry unflagged {{ $number }}">
                             <table class="gloss">
-                                <tbody><tr class="tgs_text"><td colspan="10"><a href="#">{{ $translation->trigedasleng }}</a></td></tr>
+                                <tbody><tr class="tgs_text"><td colspan="10"><a href="/translation/{{$translation->id}}">{{ $translation->trigedasleng }}</a></td></tr>
                                 <tr class="tgs" style="display: table-row;">
                                     @foreach(explode(' ', $translation->trigedasleng) as $w)
                                         <td>{{ $w }}</td>

--- a/resources/views/word/lookup.blade.php
+++ b/resources/views/word/lookup.blade.php
@@ -18,7 +18,7 @@
                 @foreach($translationList as $translation)
                     <div class="entry unflagged">
                         <table class="gloss">
-                            <tbody><tr class="tgs_text"><td colspan="10"><a href="#">{{ $translation->trigedasleng }}</a></td></tr>
+                        <tbody><tr class="tgs_text"><td colspan="10"><a href="/translation/{{$translation->id}}">{{ $translation->trigedasleng }}</a></td></tr>
                             <tr class="tgs" style="display: table-row;">
                                 @foreach(explode(' ', $translation->trigedasleng) as $w)
                                     <td>{{ $w }}</td>

--- a/routes/web.php
+++ b/routes/web.php
@@ -57,4 +57,7 @@ Route::get('/grammar', static function(){
 })->name('grammar');
 
 // Translations
+Route::get('/translation/{id}', 'WebController@translationLookup')->where('id', '[0-9]+')->name('translation.lookup');
+Route::get('/translation/{id}/edit', 'WebController@translationEdit')->where('id','[0-9]+')->name('translation.edit');
+Route::post('/translation/{id}/edit', 'WebController@translationEditSubmit')->where('id','[0-9]+')->name('translation.edit.submit');
 Route::get('/translations', 'WebController@translations')->name('translations');


### PR DESCRIPTION
This PR should close issue #11. Though if desired it could be changed quickly from using the `id` field to using either the `translation` or `trigedasleng` fields instead to make the links easier to follow at the cost of being potentially harder to type.