### PR TITLE
[FIX] Translation edit page breaks on update

### DIFF
--- a/app/Http/Controllers/WebController.php
+++ b/app/Http/Controllers/WebController.php
@@ -104,9 +104,9 @@ class WebController extends Controller
             'translation' => $request->translation,
             'etymology' => $request->etymology,
             'leipzig' => $request->leipzig,
-            'episode' => $request->episode,
+            'episode' => isset($request->episode) ? $request->episode : '',
             'audio' => $request->audio,
-            'speaker' => $request->speaker,
+            'speaker' => isset($request->speaker) ? $request->speaker : '',
             'source' => $request->source,
         ]);
         $translationInfo = DB::selectOne('SELECT * FROM `dict_translations` WHERE `id`= ?', [$request->id]);

--- a/app/Http/Controllers/WebController.php
+++ b/app/Http/Controllers/WebController.php
@@ -104,7 +104,7 @@ class WebController extends Controller
             'translation' => $request->translation,
             'etymology' => $request->etymology,
             'leipzig' => $request->leipzig,
-            'episode' => isset($request->episode) ? $request->episode : '',
+            'episode' => isset($request->episode) ? $request->episode : 'other',
             'audio' => $request->audio,
             'speaker' => isset($request->speaker) ? $request->speaker : '',
             'source' => $request->source,

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -36,7 +36,7 @@
                         <table class="gloss">
                             <tbody>
                             <tr class="tgs_text">
-                                <td colspan="10"><a href="#">{{ $randomTranslation->trigedasleng }}</a></td>
+                                <td colspan="10"><a href="/translation/{{$translation->id}}">{{ $randomTranslation->trigedasleng }}</a></td>
                             </tr>
                             <tr class="tgs" style="display: table-row;">
                                 @foreach(explode(' ', $randomTranslation->trigedasleng) as $word)


### PR DESCRIPTION
*FIX #36 
Make speaker and episode silently fail should their fields be left blank.

*FIX
Add translation link to the index blade